### PR TITLE
fix: overwrite browser list padding

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -298,7 +298,7 @@ body {
 /* About Me */
 
 .about-section__content {
-  padding: 0 2rem;
+  padding-inline-start: 0;
   margin-block-end: 0;
 }
 


### PR DESCRIPTION
Fixed the default browser injected style of `padding-inline-start` to 0.